### PR TITLE
Fixed Package.json main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coffeelint-camel-case-vars",
   "version": "0.0.4",
   "description": "A CoffeeLint rule that ensures variables are camelCased",
-  "main": "index.js",
+  "main": "index.coffee",
   "repository": {
     "type": "git",
     "url": "git://github.com/bsklaroff/coffeelint-camel-case-vars.git"


### PR DESCRIPTION
index.js isn't being shipped with npm i and you can just point directly to this. Changing this prevents this plugin from crashing atom-coffeelint.
